### PR TITLE
Update CONTRIBUTING.md with GitHub link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@
 [pr]: https://github.com/actions-workshop/actions-workshop/compare
 [issue]: https://github.com/actions-workshop/actions-workshop/issues/new
 
+[github]: https://github.com
+
 Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.
 
 ## Contributions to the Workshop Content


### PR DESCRIPTION

This pull request makes a minor update to the `CONTRIBUTING.md` documentation by adding a missing GitHub reference link. This helps ensure that all referenced links in the document are properly defined.

This pull request makes a minor update to the `CONTRIBUTING.md` file, adding a reference link to GitHub for use in documentation.